### PR TITLE
Add .gitlab-ci.yaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,34 @@
+---
+stages:
+- build
+
+variables:
+  GIT_SUBMODULE_STRATEGY: normal
+  PROD_REGISTRY: https://index.docker.io/v1/
+  PROD_REGISTRY_USER: mvitale1989
+  PROD_REGISTRY_IMAGE: index.docker.io/mvitale1989/docker-taiga
+
+before_script:
+- mkdir -p /kaniko/.docker
+- |
+  echo "{\"auths\": { \"$PROD_REGISTRY\": {\"auth\": \"`echo -n $PROD_REGISTRY_USER:$PROD_REGISTRY_PASSWORD | base64`\"}, \"$CI_REGISTRY\": {\"auth\": \"`echo -n gitlab-ci-token:$CI_JOB_TOKEN | base64`\"} }}" > /kaniko/.docker/config.json
+
+build-dev:
+  stage: build
+  image:
+    name: gcr.io/kaniko-project/executor:debug
+    entrypoint: ["/busybox/sh", "-c"]
+  script:
+  - /kaniko/executor --context $CI_PROJECT_DIR --destination $PROD_REGISTRY_IMAGE:latest --reproducible --cache --cache-repo=$CI_REGISTRY_IMAGE
+  except:
+  - tags
+
+build-prod:
+  stage: build
+  image:
+    name: gcr.io/kaniko-project/executor:debug
+    entrypoint: ["/busybox/sh", "-c"]
+  script:
+  - /kaniko/executor --context $CI_PROJECT_DIR --destination $PROD_REGISTRY_IMAGE:$CI_COMMIT_REF_NAME --reproducible --cache --cache-repo $CI_REGISTRY_IMAGE
+  only:
+  - tags


### PR DESCRIPTION
Due to Docker Hub's build system changes requiring pervasive github permissions, migrate to Gitlab CI instead.